### PR TITLE
Changing MIME type as the CSS is not uploaded correctly to CRX

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-aem-watch",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "A simple plug-in to upload files to an active AEM instance, recommended for use with grunt-contrib-watch.",
   "main": "index.js",
   "scripts": {
@@ -30,7 +30,6 @@
     "grunt": "^1.0.1",
     "grunt-contrib-watch": "^1.0.0",
     "moment": "^2.15.2",
-    "needle": "^1.3.0",
-    "mime": "^1.3.4"
+    "needle": "^1.3.0"
   }
 }

--- a/tasks/aem-watch.js
+++ b/tasks/aem-watch.js
@@ -4,8 +4,7 @@ var async = require('async'),
 	moment = require('moment'),
 	needle = require('needle'),
 	path = require('path'),
-	fs = require('fs'),
-	mime = require('mime');
+	fs = require('fs');
 
 // Declare the module
 module.exports = function (grunt) {
@@ -40,8 +39,7 @@ module.exports = function (grunt) {
 			replacePath = 'jrc_root/',
 			replacePathWith = '',
 			uploadFile = function (file) {
-				var fileName = path.basename(file).toString(),
-					mimeType = mime.lookup(file);
+				var fileName = path.basename(file).toString();
 
 				grunt.log.writeln('Uploading file', file);
 
@@ -62,7 +60,7 @@ module.exports = function (grunt) {
 				requestData = {
 					'*': {
 						'file': file,
-						'content_type': mimeType
+						'content_type': 'application/octet-stream'
 					},
 					'*@TypeHint': 'nt:file'
 				};


### PR DESCRIPTION
After some weeks using the watch, we found a bug with the content in pseudoelements.

This is a "conflict" with the needle library, encoding wrongly the non english characters which breaks the compiled CSS. Sending the MIME Type as 'application/octet-stream' fix this.